### PR TITLE
ステップ４登録画面実装

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -50,7 +50,7 @@ def step4
   session[:postalcode] = address_params[:postalcode]
   session[:city] = address_params[:city]
   session[:house_number] = address_params[:house_number]
-  session[:building_name  ] = address_params[:building_name]
+  session[:building_name] = address_params[:building_name]
   session[:prefecture] = address_params[:prefecture]
 
   # @user = User.new(
@@ -77,12 +77,38 @@ def step4
 #   end
 
   #カードのアソシエーションを組むこと。
-# @user = User.new
+@card = Card.new
 
 end
 
 
 def create
+
+  session[:card_id] = card_params[:card_id]
+  session[:security_code] = card_params[:security_code]
+  session[:month] = card_params[:month]
+  session[:year] = card_params[:year]
+  
+  @card = Card.new(
+    card_id: session[:card_id],
+    security_code: session[:security_code],
+    month: session[:month],
+    year: session[:year]
+  )
+
+  @card.save
+
+  
+  @address = Address.new(
+    postalcode: session[:postalcode],
+    city: session[:city],
+    house_number: session[:house_number],
+    building_name: session[:building_name],
+    prefecture: session[:prefecture]    
+  )
+
+  @address.save
+
   @user = User.new(
     nickname: session[:nickname], # sessionに保存された値をインスタンスに渡す
     email: session[:email],
@@ -98,10 +124,12 @@ def create
     phone_number: session[:phone_number]
 
   )
+
   if @user.save
 # ログインするための情報を保管
     session[:id] = @user.id
     redirect_to done_signup_index_path
+
   else
     render '/signup/entry_signup'
   end
@@ -139,7 +167,7 @@ end
 
   def address_params
     params.require(:address).permit(
-      :prefectures,
+      :prefecture,
       :postalcode,
       :city,
       :house_number,
@@ -148,10 +176,12 @@ end
 
   end
 
-
-
-
-  
-
-
+  def card_params
+    params.require(:card).permit(
+      :card_id,
+      :year,
+      :month,
+      :security_code
+    )
+  end
 end

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -1,2 +1,3 @@
 class Card < ApplicationRecord
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,4 +19,5 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_one :address
+  has_one :cards
 end

--- a/app/views/signup/step3.html.haml
+++ b/app/views/signup/step3.html.haml
@@ -33,7 +33,7 @@
           .register-heading-take
             住所入力
         
-        = form_with model: [@user, @address], url: step4_signup_index_path, method: :get, local: true do |f|
+        = form_with model: @address, url: step4_signup_index_path, method: :get, local: true do |f|
             
           .register-content-box-take
             .l-single-content-take
@@ -75,7 +75,7 @@
 
                 .form-group.address-prefecture-form
                   .form-group.address-prefecture-form__heading.displayflex
-                    = f.label :prefectures, "都道府県"
+                    = f.label :prefecture, "都道府県"
                     -# %label{for: "select-prefecture_pn"} 都道府県
                     %span.form-require 必須 
 
@@ -84,7 +84,7 @@
                       .address-prefecture-select-down.relative
                         .angle-position
                           = fa_icon 'angle-down', class: "address-prefecture-angle-down__absolute.angle-position"
-                        = f.collection_select :prefectures, Prefecture.all, :id, :name,{prompt:"--"},{class:"input-default"}  
+                        = f.collection_select :prefecture, Prefecture.all, :id, :name, {prompt: "--"},{class:"input-default"}
 
                 .form-group-address__phonetic.address-heading-row
                   = f.label :address_city, "市区町村"

--- a/app/views/signup/step4.html.haml
+++ b/app/views/signup/step4.html.haml
@@ -32,13 +32,18 @@
         .single-main-box
           .register-heading-take
             クレジットカード情報入力
+
+        = form_with model: @card, url: signup_index_path, method: :post, local: true do |f|
           .register-content-box-take
             .l-single-content-take
               .form-group-card
                 .form-group-card__heading.displayflex
-                  %label{for: "payment_card_num"} カード番号
+                  = f.label :card_id, "カード番号", for: "payment_card_num"
+            
                   %span.form-require 必須
-                %input.payment_card_num.input-default{"data-input-type" => "card", maxlength: "19", placeholder: "半角数字のみ", type: "text", value: ""}/
+
+                = f.text_field :card_id, class: "payment_card_num input-default", maxlength: "19", placeholder: "半角数字のみ", type: "text", value: "", "data-input-type" => "card"
+                
                 .card-icons-box.displayflex
                   %ul
                     = image_tag 'icon-visa.svg', size: '49x20'
@@ -57,50 +62,58 @@
 
               .form-group.signup-form-expire
                 .form-group.signup-form-expire__heading.displayflex
-                  %label{for: "payment_card_expire"} 有効期限
+                  = f.label :month, "有効期限", for: "payment_card_expire"
+                  
                   %span.form-require 必須      
                 .card-expiration.displayflex    
                   .card-expiration-month-box
                     .select-card-month.half.displayflex.relative
                       = fa_icon 'angle-down', class: "credit-card-angle-down__absolute"
-                      %select#payment_card_expiration_mm.select-default
-                        %option{value: "01"} 01
-                        %option{value: "02"} 02
-                        %option{value: "03"} 03
-                        %option{value: "04"} 04
-                        %option{value: "05"} 05
-                        %option{value: "06"} 06
-                        %option{value: "07"} 07
-                        %option{value: "08"} 08
-                        %option{value: "09"} 09
-                        %option{value: "10"} 10
-                        %option{value: "11"} 11
-                        %option{value: "12"} 12
+
+                      
+                      = f.select :month, [['01',1],['02',2],['03',3],['04',4],['05',5],['06',6],['07',7],['08',8],["09",9],['10',10],['11',11],['12',12]], {}, {id: "payment_card_expiration_mm",class: "select-default"} 
+                      -# %select#payment_card_expiration_mm.select-default
+                      -#   %option{value: "01"} 01
+                      -#   %option{value: "02"} 02
+                      -#   %option{value: "03"} 03
+                      -#   %option{value: "04"} 04
+                      -#   %option{value: "05"} 05
+                      -#   %option{value: "06"} 06
+                      -#   %option{value: "07"} 07
+                      -#   %option{value: "08"} 08
+                      -#   %option{value: "09"} 09
+                      -#   %option{value: "10"} 10
+                      -#   %option{value: "11"} 11
+                      -#   %option{value: "12"} 12
                       %h3 月  
 
                   .card-expiration-year-box
                     .select-card-year.half.displayflex.relative
                       = fa_icon 'angle-down', class: "credit-card-angle-down__absolute"
-                      %select#payment_card_expire_yy.select-default
-                        %option{value: "19"} 19
-                        %option{value: "20"} 20
-                        %option{value: "21"} 21
-                        %option{value: "22"} 22
-                        %option{value: "23"} 23
-                        %option{value: "24"} 24
-                        %option{value: "25"} 25
-                        %option{value: "26"} 26
-                        %option{value: "27"} 27
-                        %option{value: "28"} 28
-                        %option{value: "29"} 29
+  
+                      = f.select :year, [['2019',19],['2020',20],['2023',23],['2024',24],['2025',25],['2026',26],['2027',27],['2028',28],["2029",29]], {}, {id: "payment_card_expire_yy",class: "select-default"} 
+                      -# %select#payment_card_expire_yy.select-default
+                      -#   %option{value: "19"} 19
+                      -#   %option{value: "20"} 20
+                      -#   %option{value: "21"} 21
+                      -#   %option{value: "22"} 22
+                      -#   %option{value: "23"} 23
+                      -#   %option{value: "24"} 24
+                      -#   %option{value: "25"} 25
+                      -#   %option{value: "26"} 26
+                      -#   %option{value: "27"} 27
+                      -#   %option{value: "28"} 28
+                      -#   %option{value: "29"} 29
                       %h3 年
                     
               .signup-form-security_code
                 .signup-form-security_code__heading.displayflex
-                  %label{for: "payment_card_security_code"} セキュリティコード
+                  = f.label :security_coad, "セキュリティコード", for: "payment_card_security_code"
+                  -# %label{for: "payment_card_security_code"} セキュリティコード
                   %span.form-require 必須
                 .signup-form-security_code-box 
-                  %input#payment_card_security_code.input-default{placeholder: "カード背面4桁もしくは3桁の番号", value: ""}/
+                  = f.text_field :security_coad, class: "input-default", id: "payment_card_security_code",placeholder: "カード背面4桁もしくは3桁の番号", value: ""
+                  -# %input#payment_card_security_code.input-default{placeholder: "カード背面4桁もしくは3桁の番号", value: ""}/
                 .signup-seqcode-help
                   .signup-seqcode__text.displayflex
                     .signup-seqcode__text__icon
@@ -112,7 +125,8 @@
          
               .card-info-submit
                 .card-info-submit__btn
-                  %button#submit-button.btn-default.btn-red{type: "button"} 次へ進む
+                  = f.submit class: "btn-default btn-red", id: "submit-button", value: "次へ進む"
+                  -# %button#submit-button.btn-default.btn-red{type: "button"} 次へ進む
 
 
 

--- a/db/migrate/20191106025037_rename_prefecture_column_to_prefectures.rb
+++ b/db/migrate/20191106025037_rename_prefecture_column_to_prefectures.rb
@@ -1,0 +1,5 @@
+class RenamePrefectureColumnToPrefectures < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :addresses, :prefecture, :prefectures
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_05_060400) do
+ActiveRecord::Schema.define(version: 2019_11_06_025037) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.integer "postalcode", null: false
-    t.integer "prefecture", null: false
+    t.integer "prefectures", null: false
     t.string "city", null: false
     t.string "house_number", null: false
     t.string "building_name"


### PR DESCRIPTION
#what
カラム名を変更
アドレステーブルの
prefectureからprefecturesに変更

"why
prefectureにするとアクティブハッシュのところで
undefined method `prefecture_id' 
というエラーがでる。
おそらくprefectureに変更するとエラーが消えるため。