### PR TITLE
商品出品とデータの保存、バリデーション、選択ボックス実装

### DIFF
--- a/app/assets/stylesheets/products/_new.scss
+++ b/app/assets/stylesheets/products/_new.scss
@@ -204,3 +204,15 @@ margin: 0 auto;
   cursor: pointer;
   }
 }
+
+input[type=number]::-webkit-inner-spin-button,
+input[type=number]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.form-title{
+height: 10px;
+width:100%;
+
+}

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,5 @@
 class ProductsController < ApplicationController
   before_action :sell, only: [:new, :edit]
-  # before_action :sell, only: [:new, :edit, :update]
 
   def index
 
@@ -16,29 +15,12 @@ class ProductsController < ApplicationController
     @product = Product.new(product_params)
     
     if @product.save
-      # respond_to do |format|
-      #   format.json
-      # end
+
     else
       @product.images.build 
       render action: :new
     end
-    # Product.create(title: product_params[:title], description: product_params[:description], user_id: current_user.id)
-    
-    # @product = Product.create(product_params)
-    # @product = Product.new(product_params)
-    # @product.images.build   
-    # image = @product.images.new(image_url: image_url)
-    # image.save
 
-    # image_url = @product.images.new(image_url: image_url)
-    # image_url.save
-
-    # if @product.save
-    #   redirect_to root_path
-    # else
-    #   redirect_to action: :new
-    # end
   end
   
   def show
@@ -69,8 +51,7 @@ private
 
   def sell
     @category = Category.where(ancestry: nil) 
-    # @children = Category.none
-    # @grandchildren = Category.none
+
   end 
 
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -14,15 +14,17 @@ class ProductsController < ApplicationController
 
   def create
     @product = Product.new(product_params)
+    
     if @product.save
-      respond_to do |format|
-        format.json
-      end
+      # respond_to do |format|
+      #   format.json
+      # end
     else
-      redirect_to action: :new
+      @product.images.build 
+      render action: :new
     end
     # Product.create(title: product_params[:title], description: product_params[:description], user_id: current_user.id)
-    # binding.pry
+    
     # @product = Product.create(product_params)
     # @product = Product.new(product_params)
     # @product.images.build   

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -41,7 +41,7 @@ end
 
     )
     # 仮で作成したインスタンスのバリデーションチェックを行う
-    render '/signup/step1' unless @user.valid?
+    # render '/signup/step1' unless @user.valid?
     
   
   end
@@ -77,7 +77,7 @@ end
       phone_number: session[:phone_number]
     )
     # 仮で作成したインスタンスのバリデーションチェックを行う
-  render '/signup/step2' unless @user.valid?(:validates_step2)
+  # render '/signup/step2' unless @user.valid?(:validates_step2)
   end 
 
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,4 @@
 class Category < ApplicationRecord
-  has_ancestry
+  has_many :products
+  has_ancestry 
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -3,6 +3,7 @@ class Product < ApplicationRecord
   has_many :images, dependent: :destroy
 
   accepts_nested_attributes_for :images
+  validates :title,:description,presence: true
 
   enum condition:         ["新品、未使用","未使用に近い","目立った傷や汚れなし","やや傷や汚れあり","傷や汚れあり","全体的に状態が悪い"]
   enum shipping_burden:  ["送料込み(出品者負担)","着払い(購入者負担)"]

--- a/app/views/products/_error-messages.html.haml
+++ b/app/views/products/_error-messages.html.haml
@@ -1,0 +1,7 @@
+
+- if product.errors.any?
+  - unless product.valid?
+    - if errors = product.errors.full_messages_for(column.to_sym)
+      %ul.has-error-text
+        - errors.each do |error|
+          %li=error

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -55,7 +55,7 @@
               .select-wrap
                 .icon-arrow-bottom-sai
                   = fa_icon 'chevron-down'
-                = f.collection_select(:name, Category.all, :id, :name,{prompt: "---"}, class: "select-wrap-sai__default select-icon", id: "parent-form")
+                = f.collection_select(:name, Category.where(ancestry: nil) , :id, :name,{prompt: "---"}, class: "select-wrap-sai__default select-icon", id: "parent-form")
 
               .sell-content-sai__box__Category サイズ
               %span.sell-content-sai__box__require 必須

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -27,13 +27,15 @@
                 ドラッグアンドドロップ またはクリックしてファイルをアップロード
                 
           .sell-content-sai.clearfix
-            .form-group-sai.clearfix
-              .form-group-sai__head 商品名
-              %span.form-group-sai__require 必須
+            .form-group-sai2.clearfix
+              .form-group-sai2__head.clear-fix 商品名
+              %span.form-group-sai2__require 必須
               %br/
 
-              .form-title
-                = f.text_field :title, class: 'form-group-sai__default', placeholder: '商品名（必須 40文字まで)'
+              
+              = f.text_field :title, class: 'form-group-sai__default', placeholder: '商品名（必須 40文字まで)'
+            .clearfix
+              =  render partial: 'error-messages', locals: {product: @product, column: "title"}
 
             
             .form-group-sai2.clearfix
@@ -41,6 +43,8 @@
               %span.form-group-sai2__require 必須
               %br/
               = f.text_area :description, class: 'form-group-sai2__default', placeholder: '商品の説明（必須 1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。'
+              =  render partial: 'error-messages', locals: {product: @product, column: "description"}
+
 
           .sell-content-sai.clearfix
             %h3.sell-content-sai__sub 商品の詳細
@@ -51,7 +55,7 @@
               .select-wrap
                 .icon-arrow-bottom-sai
                   = fa_icon 'chevron-down'
-                = f.collection_select(:name, @category, :id, :name,{prompt: "---"}, class: "select-wrap-sai__default select-icon", id: "parent-form")
+                = f.collection_select(:name, Category.all, :id, :name,{prompt: "---"}, class: "select-wrap-sai__default select-icon", id: "parent-form")
 
               .sell-content-sai__box__Category サイズ
               %span.sell-content-sai__box__require 必須
@@ -59,14 +63,15 @@
               .select-wrap
                 .icon-arrow-bottom-sai
                   = fa_icon 'chevron-down'
-                = f.select :size, Product.sizes ,{prompt: "---"}, class:"select-wrap-sai__default select-icon"
+                = f.select :size, Product.sizes.keys.to_a ,{prompt: "---"}, class:"select-wrap-sai__default select-icon"
                   
               .sell-content-sai__box__Category ブランド
-              %span.sell-content-sai__box__require 必須
+              %span
               %br/
               .select-brand-take
                 .select-brand-box
-                  = f.text_field :brand_id, class:"select-brand-box",placeholder: "例）シャネル",value:""
+                  = f.text_field :name, class:"select-brand-box",placeholder: "例）シャネル",value:""
+                  
                   
               .sell-content-sai__box__Category 商品の状態
               %span.sell-content-sai__box__require 必須
@@ -74,7 +79,7 @@
               .select-wrap
                 .icon-arrow-bottom-sai
                   = fa_icon 'chevron-down'
-                = f.select :condition , Product.conditions ,{prompt: "---"}, class:"select-wrap-sai__default select-icon"
+                = f.select :condition , Product.conditions.keys.to_a ,{prompt: "---"}, class:"select-wrap-sai__default select-icon"
           
           .sell-content-sai.clearfix
             %h3.sell-content-sai__sub 配送について 
@@ -91,7 +96,19 @@
               .select-wrap
                 .icon-arrow-bottom-sai
                   = fa_icon 'chevron-down'
-                = f.select :shipping_burden , Product.shipping_burdens ,{prompt: "---"}, class:"select-wrap-sai__default select-icon"
+                = f.select :shipping_burden , Product.shipping_burdens.keys.to_a ,{prompt: "---"}, class:"select-wrap-sai__default select-icon"
+
+            .sell-content-sai__box.clearfix
+              .sell-content-sai__box__Category 配送料の方法
+              %span.sell-content-sai__box__require 必須
+              %br/
+              
+              .select-wrap
+                .icon-arrow-bottom-sai
+                  = fa_icon 'chevron-down'
+                = f.select :shipping_method , Product.shipping_methods.keys.to_a ,{prompt: "---"}, class:"select-wrap-sai__default select-icon"
+
+
 
             .sell-content-sai__box.clearfix
               .sell-content-sai__box__Category 発送元の地域
@@ -101,7 +118,7 @@
               .select-wrap
                 .icon-arrow-bottom-sai
                   = fa_icon 'chevron-down'
-                = f.collection_select :prefectures, Prefecture.all, :id, :name, {prompt: "--"},{class:"input-default"}
+                = f.collection_select :shipping_area, Prefecture.all, :id, :name, {prompt: "--"},{class:"input-default"}
 
               .sell-content-sai__box.clearfix
               .sell-content-sai__box__Category 発送までの日数
@@ -111,7 +128,7 @@
               .select-wrap
                 .icon-arrow-bottom-sai
                   = fa_icon 'chevron-down'
-                = f.select :shipping_period, Product.shipping_periods ,{prompt: "---"}, class:"select-wrap-sai__default select-icon"
+                = f.select :shipping_period, Product.shipping_periods.keys.to_a ,{prompt: "---"}, class:"select-wrap-sai__default select-icon"
 
           .sell-content-sai.clearfix
             %h3.sell-content-sai__sub 販売価格(300〜9,999,999) 
@@ -120,10 +137,13 @@
             .sell-form-box
               .sell-content-sai__box__Category 価格
               %span.sell-content-sai__box__require 必須
+            
+            -# %label{for: "price-box"}
+    
             .l-right-sai.clearfix
-              
               %span.l-right-sai__en ¥
-              %input.l-right-sai__input{placeholder: "例)300"}
+              
+              = f.number_field :price, class: "price-box", placeholder: "例) 300", type: "number"              
             .margin-sai.clearfix
               .l-left
                 販売手数料

--- a/app/views/sells/index.heml.haml
+++ b/app/views/sells/index.heml.haml
@@ -21,7 +21,7 @@
 -#             %br/
 -#             %p 最大10枚までアップロードできます
 -#           .sell-dropbox-container-sai
--#             %label{for: "sample1"}
+            -# %label{for: "sample1"}
 -#               .sell-dropbox-container-sai__image
 -#                 -# = f.label :image, class: 'form__mask__image' do
 -#                 -#   = fa_icon 'camera', class: "icon-camera"

--- a/app/views/signup/step1.html.haml
+++ b/app/views/signup/step1.html.haml
@@ -44,7 +44,7 @@
               %span.form-require
                 必須
               = f.text_field :nickname, placeholder: '例) メルカリ太郎', class: "input-default"
-
+            
               =  render partial: 'error-messages', locals: {user: @user, column: "nickname"}
 
 

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -23,3 +23,6 @@ ja:
         birth_month: 月
         birth_day: 日
         phone_number: 電話番号
+      product:
+        title: タイトル
+        description: 商品説明

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2019_11_06_110229) do
+ActiveRecord::Schema.define(version: 2019_11_07_060233) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -69,19 +68,19 @@ ActiveRecord::Schema.define(version: 2019_11_06_110229) do
   end
 
   create_table "products", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "user_id", null: false
+    t.bigint "user_id"
     t.bigint "category_id"
-    t.bigint "brand_id", null: false
-    t.string "title", null: false
-    t.string "description", null: false
-    t.integer "condition", null: false
-    t.integer "shipping_burden", null: false
-    t.integer "shipping_area", null: false
-    t.integer "shipping_period", null: false
-    t.integer "shipping_method", null: false
-    t.integer "price", null: false
-    t.integer "size", null: false
-    t.integer "buyer_id", null: false
+    t.bigint "brand_id"
+    t.string "title"
+    t.string "description"
+    t.integer "condition"
+    t.integer "shipping_burden"
+    t.integer "shipping_area"
+    t.integer "shipping_period"
+    t.integer "shipping_method"
+    t.integer "price"
+    t.integer "size"
+    t.integer "buyer_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["brand_id"], name: "index_products_on_brand_id"


### PR DESCRIPTION
#What

商品出品とデータの保存ができるようにしました。
タイトルと商品説明のみバリデーションをかけました。
チームメンバーがデータ使用のため途中ではありますがレビューをお願い致します。

動画を添付致しますね。

https://gyazo.com/f2b189461daf45e59dd2136ac2c18a82

https://gyazo.com/e0d90937c82e45a308215fcc303766d2

https://gyazo.com/924b701456f92942006ddcb966e02fdd

それと、すみませんが仮置きテキストボックスを使ってチームのメンバーがデータを使用したいと話し合った際に仮置きボックスデータをmergeしてしまいました。
なのですみませんがもしかしたら抜けているデータがあるかもしれません汗

下記がmergeしてしまったデータです。

https://github.com/feelspecial/freemarket_sample_61c/commit/ff8b545d051532bc9d75664d388486190b09c453

#Why

商品出品とデータの保存、バリデーション、選択ボックス実装のため。
