### PR TITLE
商品一覧表示・カテゴリー別＿伊藤

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -36,6 +36,7 @@ class ProductsController < ApplicationController
     # if current_user.pay.array? 
     # redirect_to  root_path 
     # else
+    @pay = Pay.where(user_id: current_user.id).first 
     @product_purchaser= Product.find(params[:product_id])
     
     # @product = Product.find(params[:product_id])
@@ -61,7 +62,8 @@ class ProductsController < ApplicationController
 
   def index
     @products = Product.all.order("created_at DESC").limit(10)
-
+    @products_mens = Product.where(:category_id => 145..267).order("created_at DESC").limit(10)
+    @products_ladies = Product.where(:category_id => 9..144).order("created_at DESC").limit(10)
     
 
     # @category = Category.find(1)

--- a/app/views/products/_content.html.haml
+++ b/app/views/products/_content.html.haml
@@ -76,14 +76,64 @@
             .popular-category__highrow.displayflex
               .popular-category__highrow__leftbox#1
                 = link_to '#0' do
+                  %h5 レディース新着アイテム
+              .popular-category__highrow__rightbox
+                = link_to '#0' do
+                  %h7 もっと見る 〉   
+        .popular-category-content__box__lowrow
+          .new-product-toplist.displayflex.clearfix
+            - @products_ladies.each do |product|  
+              .new-product-toplist__box
+                = link_to product_path(product) do
+                  %ul.fadein
+                    %li.new-product-toplist__box__image
+                      = image_tag "#{product.images.first.image_url}", size: "180×180"
+                      
+                      -if product.buyer_id.present? 
+                        .items-box_photo__sold
+                          .items-box_photo__sold__inner
+                            SOLD
+           
+
+                      .new-product-toplist__price
+                        %span￥
+                        =product.price.to_s(:delimited)
+                    %li.new-product-toplist__box__title
+                      .new-product-toplist__title
+                        = product.title          
+
+
+        .newproduct-margin
+          .popular-category-content__box__highrow
+            .popular-category__highrow.displayflex
+              .popular-category__highrow__leftbox#1
+                = link_to '#0' do
                   %h5 メンズ新着アイテム
               .popular-category__highrow__rightbox
                 = link_to '#0' do
                   %h7 もっと見る 〉   
         .popular-category-content__box__lowrow
-          .new-product-toplist.displayflex  
-            = render 'newmens'
-        = render 'newksc'
+          .new-product-toplist.displayflex.clearfix
+            - @products_mens.each do |product|  
+              .new-product-toplist__box
+                = link_to product_path(product) do
+                  %ul.fadein
+                    %li.new-product-toplist__box__image
+                      = image_tag "#{product.images.first.image_url}", size: "180×180"
+                      
+                      -if product.buyer_id.present? 
+                        .items-box_photo__sold
+                          .items-box_photo__sold__inner
+                            SOLD
+           
+
+                      .new-product-toplist__price
+                        %span￥
+                        =product.price.to_s(:delimited)
+                    %li.new-product-toplist__box__title
+                      .new-product-toplist__title
+                        = product.title
+  
 
   .popular-brand
     .popular-brand-header


### PR DESCRIPTION
商品一覧カテゴリー表示機能実装。
コントローラーとビュー編集。
例）メンズカテゴリーの場合は、メンズに分類してされるように
編集しました。
[![Screenshot from Gyazo](https://gyazo.com/6e2bf24cf1053ed685650a9ee2341cbd/raw)](https://gyazo.com/6e2bf24cf1053ed685650a9ee2341cbd)