### PR TITLE
都道府県名微修正

### DIFF
--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -98,7 +98,7 @@
             .product-exhibit-details-box__info  
               .exhibit-table__highrow
                 = link_to root_path do
-                  = @product.shipping_area
+                  = Prefecture.find(@product.shipping_area).name
 
           .product-exhibit-details-box
             .product-exhibit-details-box__heading


### PR DESCRIPTION
#What

都道府県名の表示をidから名前へ変更しました。